### PR TITLE
Add srt to vtt converter to support WebVTT.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Code School Course Subtitles
 
-This repository holds all of the subtitles currently available for Code School courses. 
-For now we focus exclusively on English subtitles but if you wish to translate the 
-subtitles into a different language we accept pull requests and will deploy these 
+This repository holds all of the subtitles currently available for Code School courses.
+For now we focus exclusively on English subtitles but if you wish to translate the
+subtitles into a different language we accept pull requests and will deploy these
 subtitles (after review) to our courses for the benefit of all.
 
 ## Contributing
-Feel free to fork this repository and work on new subtitle files in your own fork. 
-Once you've completed at least a whole video subtitle file, feel free to open a pull 
+Feel free to fork this repository and work on new subtitle files in your own fork.
+Once you've completed at least a whole video subtitle file, feel free to open a pull
 request to discuss it and we'll do our best to get it merged in a timely manner.
 
 Please name the subtitle files as follows:
@@ -18,9 +18,31 @@ Please name the subtitle files as follows:
 You can find a list of the [ISO 639-1 language codes on Wikipedia](http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) if you're not sure
 which one to use.
 
+### subtitle-converter
+
+Once you have added a new subtitle in SRT format, you can create a WebVTT copy
+by running `node subtitle-converter` in the root directory of this repository.
+For example, if you added `my-cool-course/level1-en.srt` then you can make a
+WebVTT copy using:
+
+``` shell
+npm install
+node subtitle-converter --i "my-cool-course/level1-en.srt"
+```
+
+*Options*
+
+- Input Path(s): `--i "path/to/file.srt"`
+  - Specify the subtitle files to convert
+  - Accepts glob patterns, such as `"*/level1-*.srt"`
+  - If you do not include an input path, the default path (`"**/*.srt"`) will be used
+- Output Folder: `--o "output/files/here/"`
+  - Specify the output folder
+  - If you do not include an output folder, the files will be generated in the same directory as the input files
+
 If you have a Code School account, make sure to let us know what your username is in
 your pull request. Wouldn't be surprised if you get some free stuff. :-)
 
 ## Deployment on Code School
-We will only release new subtitles to a course when all videos for all levels have 
+We will only release new subtitles to a course when all videos for all levels have
 been translated.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "subtitle-converter",
+  "version": "1.0.0",
+  "description": "Recursively find all SRT files and create WebVTT copies.",
+  "main": "subtitle-converter.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Nick Wronski <nick@codeschool.com> (https://github.com/nwronski)",
+  "license": "MIT",
+  "dependencies": {
+    "chalk": "^1.1.0",
+    "glob": "^5.0.14",
+    "minimist": "^1.1.2",
+    "srt-to-vtt": "^1.0.2"
+  }
+}

--- a/subtitle-converter.js
+++ b/subtitle-converter.js
@@ -1,0 +1,43 @@
+var srt2vtt     = require('srt-to-vtt');
+var fs          = require('fs');
+var path        = require('path');
+var argv        = require('minimist')(process.argv.slice(2));
+var glob        = require('glob');
+var chalk       = require('chalk');
+
+glob(argv['i'] || "**/*.srt", {}, function (err, files) {
+  var msg = function (message, type) {
+    if (!type) {
+      type = 'error';
+    }
+    var headerColor = type === 'error' ? 'bgRed' : 'bgGreen',
+        header = chalk[headerColor].bold(type.toUpperCase());
+    console.log(header + chalk.white.bold('\t' + message));
+  }, usePath;
+
+  function processFile(filePath) {
+  }
+
+  if (err) {
+    msg(err.message);
+  } else if (!files.length) {
+    msg('The path provided did not match any files.');
+  } else {
+    files.forEach(function (filePath) {
+      var filePathNorm = path.normalize(filePath);
+      var fileName = path.basename(filePathNorm) + '.vtt';
+      var filePathDir = argv['o'] ? argv['o'] : path.dirname(filePathNorm);
+      var usePath = path.resolve(filePathDir) + path.sep;
+      var nextPath = usePath + fileName;
+      var writer = fs.createWriteStream(nextPath);
+
+      fs.createReadStream(filePathNorm)
+        .pipe(srt2vtt())
+        .pipe(writer);
+
+      writer.on('finish', function() {
+        msg(nextPath, 'write');
+      });
+    });
+  }
+});

--- a/subtitle-converter.js
+++ b/subtitle-converter.js
@@ -15,9 +15,6 @@ glob(argv['i'] || "**/*.srt", {}, function (err, files) {
     console.log(header + chalk.white.bold('\t' + message));
   }, usePath;
 
-  function processFile(filePath) {
-  }
-
   if (err) {
     msg(err.message);
   } else if (!files.length) {


### PR DESCRIPTION
To support HTML 5 video subtitles, we need to convert our
collection of `.srt` files into `.vtt` files.

The subtitle-converter utility can scan a directory for
subtitle files and create `.vtt` copies of those files.

README.md updated with usage instructions.